### PR TITLE
Add console entrypoint to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ docopt = "^0.6.2"
 pycodestyle = "^2.8.0"
 pytest = "^6.2.5"
 
+[tool.poetry.scripts]
+jinjalint = 'jinjalint.cli:main'
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Add an entrypoint to pyproject.toml so that jinjalint installs correctly in pipx.